### PR TITLE
Fix test step comments to be shown in the results

### DIFF
--- a/Solution/vsAr.VSO.OfflineTesting/scripts/serviceTestCase.ts
+++ b/Solution/vsAr.VSO.OfflineTesting/scripts/serviceTestCase.ts
@@ -294,6 +294,7 @@ export function getTestPointsForSuite(planId, startSuiteId, includeChilds: boole
                     var tarm = <TestContracts.TestActionResultModel><any>{
                         outcome: s.outcome,
                         comment: s.comment,
+                        errorMessage: s.comment,
                         stepIdentifier: stepIdentifier,
                     };
                     if (s.sharedStepWorkItemId){


### PR DESCRIPTION
Passing comments of actionResults to the errorMessage property in the request model. This is a workaround because the API used by the offline test execution extension does not process the comment property so that it becomes visible in the test result view.

Thank you for your pull request!
By completing this pull request, you agree to the [Contributing License Agreement](https://github.com/ALM-Rangers/Offline-Test-Execution-Extension/blob/master/.github/CLA.md).

Fixes #36  .

Changes proposed in this pull request:  
- Pass comment to the errorMessage property to make it visible in the Azure Test Plans UI

@ALM-Rangers/Offline-Test-Execution-Extension